### PR TITLE
feat(db): Migration Step 1 for adding locations column

### DIFF
--- a/db/migrations/20200309133818_add_multiple_locations.js
+++ b/db/migrations/20200309133818_add_multiple_locations.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const TABLE = 'movies';
+const COLUMN_NAME = 'locations';
+const DEFAULT_LOCATION = 'San Francisco';
+
+exports.up = async (knex) => {
+  await knex.schema.table(TABLE, (table) => {
+    table.specificType(COLUMN_NAME, 'text[]');
+  });
+  // Set default value, will be done in second step
+  // await knex.raw(`ALTER TABLE ${TABLE} ALTER COLUMN ${COLUMN_NAME} SET DEFAULT '{ "${DEFAULT_LOCATION}" }' `);
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table(TABLE, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/db/migrations/20200309133818_add_multiple_locations.js
+++ b/db/migrations/20200309133818_add_multiple_locations.js
@@ -2,7 +2,7 @@
 
 const TABLE = 'movies';
 const COLUMN_NAME = 'locations';
-const DEFAULT_LOCATION = 'San Francisco';
+// const DEFAULT_LOCATION = 'San Francisco';
 
 exports.up = async (knex) => {
   await knex.schema.table(TABLE, (table) => {

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -9,6 +9,7 @@ module.exports = Bookshelf.Model.extend({
       id: this.get('id'),
       name: this.get('name'),
       release_year: this.get('release_year'),
+      locations: this.get('locations'),
       object: 'movie'
     };
   }

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -13,6 +13,7 @@ describe('movie model', () => {
         'id',
         'name',
         'release_year',
+        'locations',
         'object'
       ]);
     });


### PR DESCRIPTION
**What**: First step in migration for adding column `locations` with default of San Francisco

Details: 
- Add column `locations` with type `text[]` to database
- Default value constraint will be added in next step in order to ensure zero downtime
- Update Movie model to include new column